### PR TITLE
Make the tests green

### DIFF
--- a/src/HeapFuzzer/HFAllocation.class.st
+++ b/src/HeapFuzzer/HFAllocation.class.st
@@ -11,6 +11,8 @@ Class {
 { #category : #testing }
 HFAllocation >> isMaybeAliveIn: aHeapFuzzing [ 
 	
+	oop ifNil: [ ^ false ].
+
 	(aHeapFuzzing heap memory hashBitsOf: oop) = hash
 		ifFalse: [ ^ false ].
 	


### PR DESCRIPTION
A very small PR to restabilize the fork

isMaybeAliveIn: after remapObjects, oop can be set to nil if the object is not found